### PR TITLE
allow username and password settings

### DIFF
--- a/lib/db.js
+++ b/lib/db.js
@@ -163,9 +163,14 @@ exports = module.exports = internals.Db = class {
 
     _connect(callback) {
 
+        // this._settings has options passed with connection.
+        // below array restricts which options will be configured in settings.
+        // default does not have "user" or "password" which does not allow for
+        // user & password authentication.
+
         const settings = this._connectionOptions || {};
         if (!this._connectionOptions) {
-            ['host', 'port', 'db', 'authKey', 'timeout', 'ssl'].forEach((item) => {
+            ['host', 'port', 'db', 'authKey', 'timeout', 'ssl', 'user', 'password'].forEach((item) => {
 
                 if (this._settings[item] !== undefined) {
                     settings[item] = this._settings[item];


### PR DESCRIPTION
default configuration did not allow for user & password to be submitted.
Tweaked the connectionOptions array to allow for it.